### PR TITLE
fix: user transformer for correct type inference

### DIFF
--- a/app/transformers/user_transformer.ts
+++ b/app/transformers/user_transformer.ts
@@ -1,9 +1,8 @@
 import type User from '#models/user'
 import { BaseTransformer } from '@adonisjs/core/transformers'
-import { type JSONDataTypes } from '@adonisjs/core/types/transformers'
 
 export default class UserTransformer extends BaseTransformer<User> {
-  toObject(): JSONDataTypes {
+  toObject() {
     return this.pick(this.resource, ['id', 'fullName', 'email', 'createdAt', 'updatedAt'])
   }
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the `JSONDataTypes` type from the `toObject` method to fix incorrect type inference in the user transformer.
